### PR TITLE
Kinesis

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM wehkamp/jre:8.121.13-r0_02
-MAINTAINER Prometheus Team <prometheus-developers@googlegroups.com>
-LABEL container.name=wehkamp/prometheus-cloudwatch-exporter:1.4
 
+ENTRYPOINT [ "java", "-jar", "/cloudwatch_exporter.jar", "9106", "/config.yml" ]
 EXPOSE 9106
 
 WORKDIR /cloudwatch_exporter
@@ -15,4 +14,4 @@ RUN apk update \
 
 WORKDIR /
 COPY config.yml /
-ENTRYPOINT [ "java", "-jar", "/cloudwatch_exporter.jar", "9106", "/config.yml" ]
+LABEL container.name=wehkamp/prometheus-cloudwatch-exporter:1.4

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,4 @@ RUN apk update \
 
 WORKDIR /
 COPY config.yml /
-LABEL container.name=wehkamp/prometheus-cloudwatch-exporter:1.4
+LABEL container.name=wehkamp/prometheus-cloudwatch-exporter:1.4.1

--- a/config.yml
+++ b/config.yml
@@ -9,6 +9,93 @@ delay_seconds: 120
 period_seconds: 120
 
 metrics:
+- aws_namespace: AWS/Kinesis
+  aws_metric_name: GetRecords.Bytes
+  aws_dimensions: [StreamName]
+  aws_statistics: [Average]
+- aws_namespace: AWS/Kinesis
+  aws_metric_name: GetRecords.IteratorAgeMilliseconds
+  aws_dimensions: [StreamName]
+  aws_statistics: [Minimum, Maximum, Average]
+- aws_namespace: AWS/Kinesis
+  aws_metric_name: GetRecords.Latency
+  aws_dimensions: [StreamName]
+  aws_statistics: [Average]
+- aws_namespace: AWS/Kinesis
+  aws_metric_name: GetRecords.Records
+  aws_dimensions: [StreamName]
+  aws_statistics: [Average]
+- aws_namespace: AWS/Kinesis
+  aws_metric_name: GetRecords.Success
+  aws_dimensions: [StreamName]
+  aws_statistics: [Average]
+- aws_namespace: AWS/Kinesis
+  aws_metric_name: IncomingBytes
+  aws_dimensions: [StreamName, ShardId]
+  aws_statistics: [Average]
+- aws_namespace: AWS/Kinesis
+  aws_metric_name: IncomingRecords
+  aws_dimensions: [StreamName, ShardId]
+  aws_statistics: [Average]
+- aws_namespace: AWS/Kinesis
+  aws_metric_name: PutRecord.Bytes
+  aws_dimensions: [StreamName]
+  aws_statistics: [Average]
+- aws_namespace: AWS/Kinesis
+  aws_metric_name: PutRecord.Latency
+  aws_dimensions: [StreamName]
+  aws_statistics: [Average]
+- aws_namespace: AWS/Kinesis
+  aws_metric_name: PutRecord.Success
+  aws_dimensions: [StreamName]
+  aws_statistics: [Average]
+- aws_namespace: AWS/Kinesis
+  aws_metric_name: PutRecords.Bytes
+  aws_dimensions: [StreamName]
+  aws_statistics: [Average]
+- aws_namespace: AWS/Kinesis
+  aws_metric_name: PutRecords.Latency
+  aws_dimensions: [StreamName]
+  aws_statistics: [Average]
+- aws_namespace: AWS/Kinesis
+  aws_metric_name: PutRecords.Records
+  aws_dimensions: [StreamName]
+  aws_statistics: [Average]
+- aws_namespace: AWS/Kinesis
+  aws_metric_name: PutRecords.Success
+  aws_dimensions: [StreamName]
+  aws_statistics: [Average]
+- aws_namespace: AWS/Kinesis
+  aws_metric_name: ReadProvisionedThroughputExceeded
+  aws_dimensions: [StreamName, ShardId]
+  aws_statistics: [Minimum, Maximum]
+- aws_namespace: AWS/Kinesis
+  aws_metric_name: SubscribeToShard.RateExceeded
+  aws_dimensions: [StreamName, ConsumerName]
+- aws_namespace: AWS/Kinesis
+  aws_metric_name: SubscribeToShard.Success
+  aws_dimensions: [StreamName, ConsumerName]
+- aws_namespace: AWS/Kinesis
+  aws_metric_name: SubscribeToShardEvent.Bytes
+  aws_dimensions: [StreamName, ConsumerName]
+  aws_statistics: [Average]
+- aws_namespace: AWS/Kinesis
+  aws_metric_name: SubscribeToShardEvent.MillisBehindLatest
+  aws_dimensions: [StreamName, ConsumerName]
+  aws_statistics: [Average]
+- aws_namespace: AWS/Kinesis
+  aws_metric_name: SubscribeToShardEvent.Records
+  aws_dimensions: [StreamName, ConsumerName]
+  aws_statistics: [Average]
+- aws_namespace: AWS/Kinesis
+  aws_metric_name: SubscribeToShardEvent.Success
+  aws_dimensions: [StreamName, ConsumerName]
+  aws_statistics: [Average]
+- aws_namespace: AWS/Kinesis
+  aws_metric_name: WriteProvisionedThroughputExceeded
+  aws_dimensions: [StreamName, ShardId]
+  aws_statistics: [Minimum, Maximum]
+
 - aws_namespace: AWS/ELB
   aws_metric_name: HealthyHostCount
   aws_dimensions: [AvailabilityZone, LoadBalancerName]


### PR DESCRIPTION
This adds some metrics that'll help keep track of Kinesis.

Example:
```
aws_kinesis_get_records_bytes_average{job="aws_kinesis",stream_name="nl-wehkamp-prod-logs",} 1435216.2903225806
aws_kinesis_get_records_iterator_age_milliseconds_minimum{job="aws_kinesis",stream_name="nl-wehkamp-prod-logs",} 1163000.0
aws_kinesis_get_records_iterator_age_milliseconds_maximum{job="aws_kinesis",stream_name="nl-wehkamp-prod-logs",} 1222000.0
aws_kinesis_get_records_iterator_age_milliseconds_average{job="aws_kinesis",stream_name="nl-wehkamp-prod-logs",} 1199587.0967741935
aws_kinesis_get_records_latency_average{job="aws_kinesis",stream_name="nl-wehkamp-prod-logs",} 384.93548387096774
aws_kinesis_get_records_records_average{job="aws_kinesis",stream_name="nl-wehkamp-prod-logs",} 2113.7419354838707
aws_kinesis_get_records_success_average{job="aws_kinesis",stream_name="nl-wehkamp-prod-logs",} 1.0
```

This PR also bumps the version label so the TF code should also be changed to include `wehkamp/prometheus-cloudwatch-exporter:1.4.1` :)