### PR TITLE
Tsa 366

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ WORKDIR /
 COPY config*.yml /
 COPY exporter.sh /
 RUN chmod 755 /exporter.sh
-LABEL container.name=wehkamp/prometheus-cloudwatch-exporter:1.4.7-6
+LABEL container.name=wehkamp/prometheus-cloudwatch-exporter:1.4.7-7

--- a/config-rest.yml
+++ b/config-rest.yml
@@ -165,14 +165,6 @@ metrics:
     aws_metric_name: Latency
     aws_dimensions: [ApiName]
 
-  - aws_namespace: monitor-aws-account-limits
-    aws_metric_name: available_ips
-    aws_dimensions: [vpcid, cidrblock]
-
-  - aws_namespace: monitor-aws-account-limits
-    aws_metric_name: perc_ec2_vcpus_used
-    aws_dimensions: [ec2-vcpu]
-
   - aws_namespace: AWS/SQS
     aws_metric_name: ApproximateAgeOfOldestMessage
     aws_dimensions: [QueueName]
@@ -200,3 +192,15 @@ metrics:
   - aws_namespace: AWS/SQS
     aws_metric_name: NumberOfMessagesSent
     aws_dimensions: [QueueName]
+
+  - aws_namespace: monitor-aws-account-limits
+    aws_metric_name: available_ips
+    aws_dimensions: [vpcid, cidrblock]
+
+  - aws_namespace: monitor-aws-account-limits
+    aws_metric_name: perc_ec2_vcpus_used
+    aws_dimensions: [ec2-vcpu]
+
+  - aws_namespace: ServicesMarathon
+    aws_metric_name: ConsulRegistrationError
+    aws_dimensions: [ServiceName]

--- a/config.yml
+++ b/config.yml
@@ -524,14 +524,6 @@ metrics:
     aws_metric_name: Latency
     aws_dimensions: [ApiName]
 
-  - aws_namespace: monitor-aws-account-limits
-    aws_metric_name: available_ips
-    aws_dimensions: [vpcid, cidrblock]
-
-  - aws_namespace: monitor-aws-account-limits
-    aws_metric_name: perc_ec2_vcpus_used
-    aws_dimensions: [ec2-vcpu]
-
   - aws_namespace: AWS/SQS
     aws_metric_name: ApproximateAgeOfOldestMessage
     aws_dimensions: [QueueName]
@@ -559,3 +551,15 @@ metrics:
   - aws_namespace: AWS/SQS
     aws_metric_name: NumberOfMessagesSent
     aws_dimensions: [QueueName]
+
+  - aws_namespace: monitor-aws-account-limits
+    aws_metric_name: available_ips
+    aws_dimensions: [vpcid, cidrblock]
+
+  - aws_namespace: monitor-aws-account-limits
+    aws_metric_name: perc_ec2_vcpus_used
+    aws_dimensions: [ec2-vcpu]
+
+  - aws_namespace: ServicesMarathon
+    aws_metric_name: ConsulRegistrationError
+    aws_dimensions: [ServiceName]


### PR DESCRIPTION
Prometheus-cloudwatch-exporter 1.4.7-7:  new metric ConsulRegistrationError for marathon-services not (completely) registered in consul.