### PR TITLE
Revert "Add AllocatedStorage metric for RDS"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ WORKDIR /
 COPY config*.yml /
 COPY exporter.sh /
 RUN chmod 755 /exporter.sh
-LABEL container.name=wehkamp/prometheus-cloudwatch-exporter:1.4.7-17
+LABEL container.name=wehkamp/prometheus-cloudwatch-exporter:1.4.7-16

--- a/config-rds.yml
+++ b/config-rds.yml
@@ -79,13 +79,6 @@ metrics:
     aws_dimension_select_regex:
       DBInstanceIdentifier: ["${RDS_DB_INSTANCES_REGEX}"]
 
-  - aws_namespace: AWS/Usage
-    aws_metric_name: AllocatedStorage
-    aws_dimensions: [DBInstanceIdentifier]
-    aws_statistics: [Average]
-    aws_dimension_select_regex:
-      DBInstanceIdentifier: ["${RDS_DB_INSTANCES_REGEX}"]
-
   - aws_namespace: RDS
     aws_metric_name: DBInstanceStatus
     aws_dimensions: [DBName]


### PR DESCRIPTION
Reverts wehkamp/docker-prometheus-cloudwatch-exporter#36

This metric showed the total storage uses of all RDS instances added up.